### PR TITLE
feat: add mongo driver options constructor

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -11,6 +11,30 @@ type Driver struct {
 	dbName string
 }
 
+type Option func(d *Driver)
+
+func WithClient(client *mongo.Client) Option {
+	return func(d *Driver) {
+		d.client = client
+	}
+}
+
+func WithDbName(dbName string) Option {
+	return func(d *Driver) {
+		d.dbName = dbName
+	}
+}
+
+func NewWithOptions(options ...Option) *Driver {
+	d := &Driver{}
+
+	for _, opt := range options {
+		opt(d)
+	}
+
+	return d
+}
+
 func New(ctx context.Context) (*Driver, error) {
 	return NewWithConfig(ctx, DefaultConfig())
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -25,14 +25,18 @@ func WithDbName(dbName string) Option {
 	}
 }
 
-func NewWithOptions(options ...Option) *Driver {
+func NewWithOptions(options ...Option) (*Driver, error) {
 	d := &Driver{}
 
 	for _, opt := range options {
 		opt(d)
 	}
 
-	return d
+	if d.client == nil {
+		return nil, ErrEmptyClient
+	}
+
+	return d, nil
 }
 
 func New(ctx context.Context) (*Driver, error) {

--- a/driver/errors.go
+++ b/driver/errors.go
@@ -1,0 +1,7 @@
+package driver
+
+import "errors"
+
+var (
+	ErrEmptyClient = errors.New("mgorepo-driver: client is nil")
+)


### PR DESCRIPTION
## Description

New Driver options constructor wass added to help reuse past connections

## Task Context

### What is the current behavior?

Force to have new connection from this driver

### What is the new behavior?

We can create an empty driver to reuse past connection object

