### PR TITLE
refactor: add search orders to search options as generic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func NewRepository[
 	collectionName string,
 	filterBuilders []func(SF) (*bson.E, error),
 	updateBuilders []func(UF) (*bson.E, error),
-) Repository[M, D, SF, UF] {}
+) Repository[M, D, SF, SO, UF] {}
 ```
 
 ##### Generic constraints

--- a/builders.go
+++ b/builders.go
@@ -9,7 +9,7 @@ import (
 // the filters, or an error if one occurs. If no filters are given, it will return nil.
 // If the deletedAtField is not explicitly set, it will filter out deleted instances if
 // withTimestamps is set to true.
-func (r Repository[M, D, SF, UF]) BuildSearchFilters(opts SF) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) BuildSearchFilters(opts SF) (bson.D, error) {
 	filters := bson.D{}
 
 	deletedFilter := false
@@ -41,7 +41,7 @@ func (r Repository[M, D, SF, UF]) BuildSearchFilters(opts SF) (bson.D, error) {
 // BuildSearchOptions builds filters, and mongo.FindOptions from a SearchOptions struct.
 // If no limit is given, it will default to the repository's search limit. If no orders
 // are given, it will default to ascending order by id.
-func (r Repository[M, D, SF, UF]) BuildSearchOptions(opts SearchOptioner[SF]) (bson.D, *options.FindOptions, error) {
+func (r Repository[M, D, SF, SO, UF]) BuildSearchOptions(opts SearchOptioner[SF, SO]) (bson.D, *options.FindOptions, error) {
 	bsonFilters, err := r.BuildSearchFilters(opts.Filters())
 	if err != nil {
 		r.logErrorf(err, buildSearchOptions, "error building search filters for %s", r.collectionName)
@@ -57,7 +57,7 @@ func (r Repository[M, D, SF, UF]) BuildSearchOptions(opts SearchOptioner[SF]) (b
 	return bsonFilters, findOpts, nil
 }
 
-func (r Repository[M, D, SF, UF]) buildProjection(opts SearchOptioner[SF]) bson.M {
+func (r Repository[M, D, SF, SO, UF]) buildProjection(opts SearchOptioner[SF, SO]) bson.M {
 	projection := bson.M{}
 
 	for field, val := range opts.Projection() {
@@ -67,7 +67,7 @@ func (r Repository[M, D, SF, UF]) buildProjection(opts SearchOptioner[SF]) bson.
 	return projection
 }
 
-func (r Repository[M, D, SF, UF]) buildFindOptions(opts SearchOptioner[SF]) (*options.FindOptions, error) {
+func (r Repository[M, D, SF, SO, UF]) buildFindOptions(opts SearchOptioner[SF, SO]) (*options.FindOptions, error) {
 	bsonOrders, err := r.BuildSearchOrders(opts.Orders())
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r Repository[M, D, SF, UF]) buildFindOptions(opts SearchOptioner[SF]) (*op
 // BuildUpdateFields builds the update fields from the given options and returns a bson.D
 // that can be used to update the document. If repository is configured with timestamps, it
 // will automatically add the updatedAtField to the update fields.
-func (r Repository[M, D, SF, UF]) BuildUpdateFields(fields UF) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) BuildUpdateFields(fields UF) (bson.D, error) {
 	bsonFields := bson.D{}
 
 	for _, builder := range r.updateBuilders {
@@ -121,7 +121,7 @@ func (r Repository[M, D, SF, UF]) BuildUpdateFields(fields UF) (bson.D, error) {
 	return bsonFields, nil
 }
 
-func (r Repository[M, D, SF, UF]) BuildSearchOrders(so SearchOrderer) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) BuildSearchOrders(so SearchOrderer) (bson.D, error) {
 	ordersMap := so.ToMap()
 
 	if len(ordersMap) == 0 {

--- a/count.go
+++ b/count.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Count returns the number of documents in the collection that match the given search options.
-func (r Repository[M, D, SF, UF]) Count(ctx context.Context, opts SF) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) Count(ctx context.Context, opts SF) (int64, error) {
 	filters, err := r.BuildSearchFilters(opts)
 	if err != nil {
 		return 0, err

--- a/create.go
+++ b/create.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Create creates a new record on the collection based on the model.
-func (r Repository[M, D, SF, UF]) Create(ctx context.Context, model M) (M, error) {
+func (r Repository[M, D, SF, SO, UF]) Create(ctx context.Context, model M) (M, error) {
 	var zeroM M
 
 	data, err := r.createBuildData(model)
@@ -33,7 +33,7 @@ func (r Repository[M, D, SF, UF]) Create(ctx context.Context, model M) (M, error
 	return resModel, err
 }
 
-func (r Repository[M, D, SF, UF]) createBuildModel(data bson.M) (M, error) {
+func (r Repository[M, D, SF, SO, UF]) createBuildModel(data bson.M) (M, error) {
 	var zeroM M
 
 	dao := new(D)
@@ -54,7 +54,7 @@ func (r Repository[M, D, SF, UF]) createBuildModel(data bson.M) (M, error) {
 	return filler.ToModel(), nil
 }
 
-func (r Repository[M, D, SF, UF]) createBuildData(model M) (bson.M, error) {
+func (r Repository[M, D, SF, SO, UF]) createBuildData(model M) (bson.M, error) {
 	dao := any(new(D)).(DaoFiller[M])
 
 	if errDao := dao.FromModel(model); errDao != nil {

--- a/delete.go
+++ b/delete.go
@@ -9,7 +9,7 @@ import (
 
 // Delete deletes a document by id. If the repository is configured to not use timestamps, this operation will be
 // applied as a hard delete.
-func (r Repository[M, D, SF, UF]) Delete(ctx context.Context, id string) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) Delete(ctx context.Context, id string) (int64, error) {
 	if !r.withTimestamps {
 		return r.HardDelete(ctx, id)
 	}

--- a/delete_many.go
+++ b/delete_many.go
@@ -8,7 +8,7 @@ import (
 
 // DeleteMany deletes many documents from the collection. It returns the number of deleted documents and an error.
 // If the repository has timestamps enabled, it will soft delete the documents. Otherwise, it will hard delete them.
-func (r Repository[M, D, SF, UF]) DeleteMany(ctx context.Context, filters SF) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) DeleteMany(ctx context.Context, filters SF) (int64, error) {
 	if !r.withTimestamps {
 		return r.HardDeleteMany(ctx, filters)
 	}
@@ -38,7 +38,7 @@ func (r Repository[M, D, SF, UF]) DeleteMany(ctx context.Context, filters SF) (i
 	return res.ModifiedCount, nil
 }
 
-func (r Repository[M, D, SF, UF]) deleteManyFilters(filters SF) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) deleteManyFilters(filters SF) (bson.D, error) {
 	if r.IsSearchFiltersEmpty(filters) {
 		r.logErrorf(ErrEmptyFilters, actionDeleteMany, "error deleting many %s document", r.collectionName)
 		return nil, ErrEmptyFilters

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -35,7 +35,8 @@ func searchExample(d mgorepo.Driver) {
 	// Search users with age 21
 	age := 21
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{GreaterThanAge: &age})
+	orders := NewSearchOrders()
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{GreaterThanAge: &age}, orders)
 
 	users, errSearch := repo.Search(context.Background(), opts)
 	if errSearch != nil {
@@ -55,8 +56,8 @@ func searchAndSortExample(d mgorepo.Driver) {
 	// Search users with age 21
 	age := 21
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{GreaterThanAge: &age}).
-		WithOrder("age", mgorepo.OrderDesc)
+	orders := NewSearchOrders().Add("age", mgorepo.OrderDesc)
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{GreaterThanAge: &age}, orders)
 
 	users, errSearch := repo.Search(context.Background(), opts)
 	if errSearch != nil {
@@ -76,7 +77,8 @@ func searchOneExample(d mgorepo.Driver) {
 	// Search user with name "name_1"
 	name := "name_1"
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}).
+	orders := NewSearchOrders()
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}, orders).
 		WithLimit(1)
 
 	user, errSearch := repo.Search(context.Background(), opts)
@@ -95,7 +97,8 @@ func getExample(d mgorepo.Driver) {
 	// Search user with name "name_1"
 	name := "name_1"
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}).
+	orders := NewSearchOrders()
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}, orders).
 		WithLimit(1)
 
 	users, errSearch := repo.Search(context.Background(), opts)
@@ -120,7 +123,8 @@ func updateExample(d mgorepo.Driver) {
 
 	name := "name_1"
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}).
+	orders := NewSearchOrders()
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}, orders).
 		WithLimit(1)
 
 	users, errSearch := repo.Search(context.Background(), opts)
@@ -156,7 +160,8 @@ func deleteExample(d mgorepo.Driver) {
 
 	name := "name_1"
 
-	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}).
+	orders := NewSearchOrders()
+	opts := mgorepo.NewSearchOptions(UserSearchFilters{Name: &name}, orders).
 		WithLimit(1)
 
 	users, errSearch := repo.Search(context.Background(), opts)

--- a/example/basic/repository.go
+++ b/example/basic/repository.go
@@ -9,7 +9,7 @@ import (
 const collection = "users"
 
 type UserRepository struct {
-	mgorepo.Repository[UserModel, UserDao, UserSearchFilters, UserUpdateFields]
+	mgorepo.Repository[UserModel, UserDao, UserSearchFilters, SearchOrders, UserUpdateFields]
 }
 
 func NewUserRepository(db mgorepo.Driver) UserRepository {
@@ -18,6 +18,7 @@ func NewUserRepository(db mgorepo.Driver) UserRepository {
 			UserModel,
 			UserDao,
 			UserSearchFilters,
+			SearchOrders,
 			UserUpdateFields,
 		](
 			db,

--- a/example/basic/search_orders.go
+++ b/example/basic/search_orders.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/Drafteame/mgorepo"
+
+type SearchOrders struct {
+	mgorepo.SearchOrders
+}
+
+func NewSearchOrders() SearchOrders {
+	return SearchOrders{
+		SearchOrders: mgorepo.NewSearchOrders(),
+	}
+}
+
+func (so SearchOrders) Add(name string, order int) SearchOrders {
+	so.SearchOrders = so.SearchOrders.Add(name, order)
+	return so
+}
+
+func (so SearchOrders) ToMap() map[string]int {
+	return so.SearchOrders.ToMap()
+}

--- a/get.go
+++ b/get.go
@@ -9,7 +9,7 @@ import (
 	mgo "go.mongodb.org/mongo-driver/mongo"
 )
 
-func (r Repository[M, D, SF, UF]) Get(ctx context.Context, id string) (M, error) {
+func (r Repository[M, D, SF, SO, UF]) Get(ctx context.Context, id string) (M, error) {
 	var dao D
 	var zeroM M
 

--- a/hard_delete.go
+++ b/hard_delete.go
@@ -7,7 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func (r Repository[M, D, SF, UF]) HardDelete(ctx context.Context, id string) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) HardDelete(ctx context.Context, id string) (int64, error) {
 	oid, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		r.logErrorf(err, actionHardDelete, "error converting %s to ObjectID", id)

--- a/hard_delete_many.go
+++ b/hard_delete_many.go
@@ -2,7 +2,7 @@ package mgorepo
 
 import "context"
 
-func (r Repository[M, D, SF, UF]) HardDeleteMany(ctx context.Context, filters SF) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) HardDeleteMany(ctx context.Context, filters SF) (int64, error) {
 	if r.IsSearchFiltersEmpty(filters) {
 		r.logErrorf(ErrEmptyFilters, actionHardDeleteMany, "empty search filters for %s hard delete", r.collectionName)
 		return 0, ErrEmptyFilters

--- a/helpers.go
+++ b/helpers.go
@@ -6,22 +6,22 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func (r Repository[M, D, SF, UF]) IsSearchFiltersEmpty(opts SF) bool {
+func (r Repository[M, D, SF, SO, UF]) IsSearchFiltersEmpty(opts SF) bool {
 	return reflect.DeepEqual(*new(SF), opts)
 }
 
-func (r Repository[M, D, SF, UF]) IsSortOptionsEmpty(opts SearchOrders) bool {
+func (r Repository[M, D, SF, SO, UF]) IsSortOptionsEmpty(opts SearchOrders) bool {
 	return len(opts) == 0
 }
 
-func (r Repository[M, D, SF, UF]) IsSearchOptionsEmpty(opt SearchOptions[SF]) bool {
-	return reflect.DeepEqual(SearchOptions[SF]{}, opt) || reflect.DeepEqual(NewSearchOptions(*new(SF)), opt)
+func (r Repository[M, D, SF, SO, UF]) IsSearchOptionsEmpty(opt SearchOptions[SF, SO]) bool {
+	return reflect.DeepEqual(SearchOptions[SF, SO]{}, opt) || reflect.DeepEqual(NewSearchOptions(*new(SF), *new(SO)), opt)
 }
 
-func (r Repository[M, D, SF, UF]) IsUpdateFieldsEmpty(fields UF) bool {
+func (r Repository[M, D, SF, SO, UF]) IsUpdateFieldsEmpty(fields UF) bool {
 	return reflect.DeepEqual(*new(UF), fields)
 }
 
-func (r Repository[M, D, SF, UF]) Now() primitive.DateTime {
+func (r Repository[M, D, SF, SO, UF]) Now() primitive.DateTime {
 	return primitive.NewDateTimeFromTime(r.clock.Now())
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -37,9 +37,9 @@ type SearchOrderer interface {
 	ToMap() map[string]int
 }
 
-type SearchOptioner[SF SearchFilters] interface {
+type SearchOptioner[SF SearchFilters, O SearchOrderer] interface {
 	Filters() SF
-	Orders() SearchOrderer
+	Orders() O
 	Limit() int64
 	Skip() int64
 	Projection() map[string]int

--- a/repository.go
+++ b/repository.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Drafteame/mgorepo/logger"
 )
 
-type Repository[M Model, D Dao, SF SearchFilters, UF UpdateFields] struct {
+type Repository[M Model, D Dao, SF SearchFilters, SO SearchOrderer, UF UpdateFields] struct {
 	db             Driver
 	clock          Clock
 	log            Logger
@@ -31,14 +31,15 @@ func NewRepository[
 	M Model,
 	D Dao,
 	SF SearchFilters,
+	SO SearchOrderer,
 	UF UpdateFields,
 ](
 	db Driver,
 	collectionName string,
 	filterBuilders []func(SF) (*bson.E, error),
 	updateBuilders []func(UF) (*bson.E, error),
-) Repository[M, D, SF, UF] {
-	return Repository[M, D, SF, UF]{
+) Repository[M, D, SF, SO, UF] {
+	return Repository[M, D, SF, SO, UF]{
 		db:             db,
 		clock:          clock.New(),
 		log:            logger.New(),
@@ -54,27 +55,27 @@ func NewRepository[
 	}
 }
 
-func (r Repository[M, D, SF, UF]) Db() Driver {
+func (r Repository[M, D, SF, SO, UF]) Db() Driver {
 	return r.db
 }
 
-func (r Repository[M, D, SF, UF]) Clock() Clock {
+func (r Repository[M, D, SF, SO, UF]) Clock() Clock {
 	return r.clock
 }
 
-func (r Repository[M, D, SF, UF]) Logger() Logger {
+func (r Repository[M, D, SF, SO, UF]) Logger() Logger {
 	return r.log
 }
 
-func (r Repository[M, D, SF, UF]) CollectionName() string {
+func (r Repository[M, D, SF, SO, UF]) CollectionName() string {
 	return r.collectionName
 }
 
-func (r Repository[M, D, SF, UF]) Collection() *mongo.Collection {
+func (r Repository[M, D, SF, SO, UF]) Collection() *mongo.Collection {
 	return r.db.Client().Database(r.db.DbName()).Collection(r.collectionName)
 }
 
-func (r Repository[M, D, SF, UF]) SetUpdatedAtField(updatedAtField string) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetUpdatedAtField(updatedAtField string) Repository[M, D, SF, SO, UF] {
 	if updatedAtField == "" {
 		updatedAtField = DefaultUpdatedAtField
 	}
@@ -84,7 +85,7 @@ func (r Repository[M, D, SF, UF]) SetUpdatedAtField(updatedAtField string) Repos
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetCreatedAtField(createdAtField string) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetCreatedAtField(createdAtField string) Repository[M, D, SF, SO, UF] {
 	if createdAtField == "" {
 		createdAtField = DefaultCreatedAtField
 	}
@@ -94,7 +95,7 @@ func (r Repository[M, D, SF, UF]) SetCreatedAtField(createdAtField string) Repos
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetDeletedAtField(deletedAtField string) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetDeletedAtField(deletedAtField string) Repository[M, D, SF, SO, UF] {
 	if deletedAtField == "" {
 		deletedAtField = DefaultDeletedAtField
 	}
@@ -103,22 +104,22 @@ func (r Repository[M, D, SF, UF]) SetDeletedAtField(deletedAtField string) Repos
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetLogger(log Logger) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetLogger(log Logger) Repository[M, D, SF, SO, UF] {
 	r.log = log
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetClock(clock Clock) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetClock(clock Clock) Repository[M, D, SF, SO, UF] {
 	r.clock = clock
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetLogLevel(logLevel string) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetLogLevel(logLevel string) Repository[M, D, SF, SO, UF] {
 	r.logLevel = strings.ToUpper(logLevel)
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) SetDefaultSearchLimit(searchLimit int) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) SetDefaultSearchLimit(searchLimit int) Repository[M, D, SF, SO, UF] {
 	if searchLimit <= 0 {
 		searchLimit = DefaultSearchLimit
 	}
@@ -127,18 +128,18 @@ func (r Repository[M, D, SF, UF]) SetDefaultSearchLimit(searchLimit int) Reposit
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) WithTimestamps(withTimestamps bool) Repository[M, D, SF, UF] {
+func (r Repository[M, D, SF, SO, UF]) WithTimestamps(withTimestamps bool) Repository[M, D, SF, SO, UF] {
 	r.withTimestamps = withTimestamps
 	return r
 }
 
-func (r Repository[M, D, SF, UF]) logErrorf(err error, action, message string, args ...any) {
+func (r Repository[M, D, SF, SO, UF]) logErrorf(err error, action, message string, args ...any) {
 	if r.log != nil && r.logLevel == logger.LevelError {
 		r.log.Errorf(err, action, message, args...)
 	}
 }
 
-func (r Repository[M, D, SF, UF]) logDebugf(action, message string, args ...any) {
+func (r Repository[M, D, SF, SO, UF]) logDebugf(action, message string, args ...any) {
 	if r.log != nil && r.logLevel == logger.LevelDebug {
 		r.log.Debugf(action, message, args...)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -18,6 +18,7 @@ func TestNewRepository(t *testing.T) {
 		testModel,
 		testDAO,
 		searchFilters,
+		SearchOrders,
 		updateFields,
 	](
 		d,

--- a/search.go
+++ b/search.go
@@ -7,7 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func (r Repository[M, D, SF, UF]) Search(ctx context.Context, opts SearchOptioner[SF]) ([]M, error) {
+func (r Repository[M, D, SF, SO, UF]) Search(ctx context.Context, opts SearchOptioner[SF, SO]) ([]M, error) {
 	filters, findOpts, err := r.BuildSearchOptions(opts)
 	if err != nil {
 		r.logErrorf(err, actionSearch, "error building SearchOptions")
@@ -17,7 +17,7 @@ func (r Repository[M, D, SF, UF]) Search(ctx context.Context, opts SearchOptione
 	return r.searchExecute(ctx, filters, findOpts)
 }
 
-func (r Repository[M, D, SF, UF]) searchExecute(ctx context.Context, filters bson.D, findOptions *options.FindOptions) ([]M, error) {
+func (r Repository[M, D, SF, SO, UF]) searchExecute(ctx context.Context, filters bson.D, findOptions *options.FindOptions) ([]M, error) {
 	var result []D
 
 	r.printSearchDebug(filters, findOptions)
@@ -47,7 +47,7 @@ func (r Repository[M, D, SF, UF]) searchExecute(ctx context.Context, filters bso
 	return models, nil
 }
 
-func (r Repository[M, D, SF, UF]) printSearchDebug(filters bson.D, findOpts *options.FindOptions) {
+func (r Repository[M, D, SF, SO, UF]) printSearchDebug(filters bson.D, findOpts *options.FindOptions) {
 	var shallowOpts options.FindOptions
 	var skip, limit int64
 

--- a/search_options.go
+++ b/search_options.go
@@ -5,60 +5,55 @@ const (
 	FieldRemove = 0
 )
 
-type SearchOptions[SF SearchFilters] struct {
+type SearchOptions[SF SearchFilters, SO SearchOrderer] struct {
 	filters    SF
-	orders     SearchOrders
+	orders     SO
 	limit      int64
 	skip       int64
 	projection map[string]int
 }
 
-var _ SearchOptioner[SearchFilters] = SearchOptions[SearchFilters]{}
+var _ SearchOptioner[SearchFilters, SearchOrderer] = SearchOptions[SearchFilters, SearchOrderer]{}
 
-func NewSearchOptions[SF SearchFilters](filters SF) SearchOptions[SF] {
-	return SearchOptions[SF]{
+func NewSearchOptions[SF SearchFilters, SO SearchOrderer](filters SF, orders SO) SearchOptions[SF, SO] {
+	return SearchOptions[SF, SO]{
 		filters: filters,
-		orders:  NewSearchOrders(),
+		orders:  orders,
 		limit:   DefaultSearchLimit,
 	}
 }
 
-func (so SearchOptions[SF]) Filters() SF {
+func (so SearchOptions[SF, SO]) Filters() SF {
 	return so.filters
 }
 
-func (so SearchOptions[SF]) Orders() SearchOrderer {
+func (so SearchOptions[SF, SO]) Orders() SO {
 	return so.orders
 }
 
-func (so SearchOptions[SF]) Limit() int64 {
+func (so SearchOptions[SF, SO]) Limit() int64 {
 	return so.limit
 }
 
-func (so SearchOptions[SF]) Skip() int64 {
+func (so SearchOptions[SF, SO]) Skip() int64 {
 	return so.skip
 }
 
-func (so SearchOptions[SF]) Projection() map[string]int {
+func (so SearchOptions[SF, SO]) Projection() map[string]int {
 	return so.projection
 }
 
-func (so SearchOptions[SF]) WithOrder(field string, order int) SearchOptions[SF] {
-	so.orders = so.orders.Add(field, order)
-	return so
-}
-
-func (so SearchOptions[SF]) WithLimit(limit int64) SearchOptions[SF] {
+func (so SearchOptions[SF, SO]) WithLimit(limit int64) SearchOptions[SF, SO] {
 	so.limit = limit
 	return so
 }
 
-func (so SearchOptions[SF]) WithSkip(skip int64) SearchOptions[SF] {
+func (so SearchOptions[SF, SO]) WithSkip(skip int64) SearchOptions[SF, SO] {
 	so.skip = skip
 	return so
 }
 
-func (so SearchOptions[SF]) Project(field string, project int) SearchOptions[SF] {
+func (so SearchOptions[SF, SO]) WithProject(field string, project int) SearchOptions[SF, SO] {
 	if field == "" {
 		return so
 	}
@@ -72,19 +67,19 @@ func (so SearchOptions[SF]) Project(field string, project int) SearchOptions[SF]
 	return so
 }
 
-func (so SearchOptions[SF]) ProjectFields(project map[string]int) SearchOptions[SF] {
+func (so SearchOptions[SF, SO]) WithProjectFields(project map[string]int) SearchOptions[SF, SO] {
 	if project == nil {
 		return so
 	}
 
 	for field, val := range project {
-		so = so.Project(field, val)
+		so = so.WithProject(field, val)
 	}
 
 	return so
 }
 
-func (so SearchOptions[SF]) normalizeProjection(val int) int {
+func (so SearchOptions[SF, SO]) normalizeProjection(val int) int {
 	if val <= 0 {
 		return 0
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -34,7 +34,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters().WithIdentifier("identifier"))
+		opt := NewSearchOptions(newSearchFilters().WithIdentifier("identifier"), NewSearchOrders())
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -44,7 +44,7 @@ func TestRepository_Search(t *testing.T) {
 	t.Run("empty search", func(t *testing.T) {
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters())
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders())
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -64,7 +64,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).WithLimit(1)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithLimit(1)
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).WithSkip(1)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithSkip(1)
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -121,7 +121,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).WithOrder(sortableField, 1)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders().Add(sortableField, 1))
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).WithOrder(sortableField, -1)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders().Add(sortableField, -1))
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters())
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders())
 		models, err := repo.Search(context.Background(), opt)
 
 		assert.NoError(t, err)
@@ -211,9 +211,8 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).
-			Project(sortableField, FieldAdd).
-			WithOrder(sortableField, 1)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders().Add(sortableField, 1)).
+			WithProject(sortableField, FieldAdd)
 
 		models, err := repo.Search(context.Background(), opt)
 
@@ -253,9 +252,8 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).
-			Project(sortableField, FieldRemove).
-			WithOrder(sortableField, OrderAsc)
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders().Add(sortableField, OrderAsc)).
+			WithProject(sortableField, FieldRemove)
 
 		models, err := repo.Search(context.Background(), opt)
 
@@ -300,13 +298,12 @@ func TestRepository_Search(t *testing.T) {
 
 		repo := newTestRepository(d)
 
-		opt := NewSearchOptions(newSearchFilters()).
-			ProjectFields(map[string]int{
+		opt := NewSearchOptions(newSearchFilters(), NewSearchOrders().Add(sortableField, 1)).
+			WithProjectFields(map[string]int{
 				idField:         FieldRemove,
 				identifierField: FieldAdd,
 				sortableField:   FieldAdd,
-			}).
-			WithOrder(sortableField, 1)
+			})
 
 		models, err := repo.Search(context.Background(), opt)
 

--- a/test_repository.go
+++ b/test_repository.go
@@ -9,11 +9,12 @@ import (
 
 const collection = "model"
 
-func newTestRepository(driver Driver) Repository[testModel, testDAO, searchFilters, updateFields] {
+func newTestRepository(driver Driver) Repository[testModel, testDAO, searchFilters, SearchOrders, updateFields] {
 	return NewRepository[
 		testModel,
 		testDAO,
 		searchFilters,
+		SearchOrders,
 		updateFields,
 	](
 		driver,

--- a/update.go
+++ b/update.go
@@ -8,7 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func (r Repository[M, D, SF, UF]) Update(ctx context.Context, id string, fields UF) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) Update(ctx context.Context, id string, fields UF) (int64, error) {
 	filters, errFilters := r.updateFilters(id)
 	if errFilters != nil {
 		r.logErrorf(errFilters, actionUpdate, "error updating %s document", r.collectionName)
@@ -32,7 +32,7 @@ func (r Repository[M, D, SF, UF]) Update(ctx context.Context, id string, fields 
 	return res.ModifiedCount, nil
 }
 
-func (r Repository[M, D, SF, UF]) updateFilters(id string) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) updateFilters(id string) (bson.D, error) {
 	oid, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, errors.Join(ErrInvalidIDFilter, err)
@@ -45,7 +45,7 @@ func (r Repository[M, D, SF, UF]) updateFilters(id string) (bson.D, error) {
 	return filters, nil
 }
 
-func (r Repository[M, D, SF, UF]) updateData(fields UF, allowEmpty bool) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) updateData(fields UF, allowEmpty bool) (bson.D, error) {
 	if !allowEmpty && r.IsUpdateFieldsEmpty(fields) {
 		return nil, ErrEmptyUpdate
 	}

--- a/update_many.go
+++ b/update_many.go
@@ -6,7 +6,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func (r Repository[M, D, SF, UF]) UpdateMany(ctx context.Context, opts SF, data UF) (int64, error) {
+func (r Repository[M, D, SF, SO, UF]) UpdateMany(ctx context.Context, opts SF, data UF) (int64, error) {
 	filters, err := r.updateManyFilters(opts)
 	if err != nil {
 		return 0, err
@@ -29,7 +29,7 @@ func (r Repository[M, D, SF, UF]) UpdateMany(ctx context.Context, opts SF, data 
 	return res.ModifiedCount, nil
 }
 
-func (r Repository[M, D, SF, UF]) updateManyFilters(opts SF) (bson.D, error) {
+func (r Repository[M, D, SF, SO, UF]) updateManyFilters(opts SF) (bson.D, error) {
 	filters, err := r.BuildSearchFilters(opts)
 	if err != nil {
 		return nil, err

--- a/update_many_test.go
+++ b/update_many_test.go
@@ -60,7 +60,7 @@ func TestRepository_UpdateMany(t *testing.T) {
 		assert.NoError(t, errUpdate)
 		assert.Equal(t, total, updated)
 
-		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters()).WithLimit(100))
+		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithLimit(100))
 		if errFind != nil {
 			t.Fatal(errFind)
 		}
@@ -105,7 +105,7 @@ func TestRepository_UpdateMany(t *testing.T) {
 		assert.ErrorIs(t, errUpdate, ErrEmptyUpdate)
 		assert.Equal(t, int64(0), updated)
 
-		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters()).WithLimit(100))
+		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithLimit(100))
 		if errFind != nil {
 			t.Fatal(errFind)
 		}
@@ -144,7 +144,7 @@ func TestRepository_UpdateMany(t *testing.T) {
 		assert.ErrorIs(t, errUpdate, ErrEmptyFilters)
 		assert.Equal(t, int64(0), updated)
 
-		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters()).WithLimit(100))
+		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithLimit(100))
 		if errFind != nil {
 			t.Fatal(errFind)
 		}
@@ -184,7 +184,7 @@ func TestRepository_UpdateMany(t *testing.T) {
 		assert.NoError(t, errUpdate)
 		assert.Equal(t, expTotal, updated)
 
-		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters()).WithLimit(100))
+		allDocs, errFind := repo.Search(context.Background(), NewSearchOptions(newSearchFilters(), NewSearchOrders()).WithLimit(100))
 		if errFind != nil {
 			t.Fatal(errFind)
 		}


### PR DESCRIPTION
## Description

Refactor SearchOptioner interface to hold SearchOrderer as generic type

## Task Context

### What is the current behavior?

<!-- current functionality without PR -->

### What is the new behavior?

<!-- expected functionality with PR -->

### Additional Context

<!-- Add here any additional context you think is important. -->

## Checklist

### Test Preview

