### PR TITLE
fix: remove search limit from search options constructor

### DIFF
--- a/search_options.go
+++ b/search_options.go
@@ -19,7 +19,6 @@ func NewSearchOptions[SF SearchFilters, SO SearchOrderer](filters SF, orders SO)
 	return SearchOptions[SF, SO]{
 		filters: filters,
 		orders:  orders,
-		limit:   DefaultSearchLimit,
 	}
 }
 


### PR DESCRIPTION
## Description

Se remueve el seteo del defaultLimit del constructor, para no interferir con la logica del limite del service.
De todas formas, cuando se buildean internamente las search options, el builder ya ataja un defaultLimit no seteado por el caller y lo setea en defaultLimit