### PR TITLE
fix: remove unnecesary default sort

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -125,7 +125,7 @@ func (r Repository[M, D, SF, SORD, SO, UF]) BuildSearchOrders(so SearchOrderer) 
 	ordersMap := so.ToMap()
 
 	if len(ordersMap) == 0 {
-		return bson.D{{Key: "_id", Value: 1}}, nil
+		return nil, nil
 	}
 
 	var orders bson.D


### PR DESCRIPTION
## Description

Tener un default sort por id parece tener un comportamiento extraño en combinación con las proyecciones, y actualmente nos esta generando timeouts en queries que sin el sort no dan problema.

https://drafteame.slack.com/archives/C02RR1K7MTP/p1694443971638779

## Task Context

### What is the current behavior?

Si no se da un sorting, se toma por defecto el sorting por id

### What is the new behavior?

Si no se da un sorting, no se agregan sort options a la query de mongo
