### PR TITLE
feat: force search limit

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -79,7 +79,7 @@ func (r Repository[M, D, SF, SORD, SO, UF]) buildFindOptions(opts SO) (*options.
 		findOpts.SetLimit(int64(r.searchLimit))
 	}
 
-	if opts.Limit() <= int64(r.searchLimit) {
+	if opts.Limit() <= int64(r.maxSearchLimit) {
 		findOpts.SetLimit(opts.Limit())
 	} else {
 		findOpts.SetLimit(int64(r.maxSearchLimit))

--- a/builders.go
+++ b/builders.go
@@ -75,7 +75,7 @@ func (r Repository[M, D, SF, SORD, SO, UF]) buildFindOptions(opts SO) (*options.
 
 	findOpts := options.Find()
 
-	if opts.Limit() > 0 {
+	if opts.Limit() > 0 && opts.Limit() <= int64(r.searchLimit) {
 		findOpts.SetLimit(opts.Limit())
 	} else {
 		findOpts.SetLimit(int64(r.searchLimit))

--- a/builders.go
+++ b/builders.go
@@ -75,10 +75,14 @@ func (r Repository[M, D, SF, SORD, SO, UF]) buildFindOptions(opts SO) (*options.
 
 	findOpts := options.Find()
 
-	if opts.Limit() > 0 && opts.Limit() <= int64(r.searchLimit) {
+	if opts.Limit() <= 0 {
+		findOpts.SetLimit(int64(r.searchLimit))
+	}
+
+	if opts.Limit() <= int64(r.searchLimit) {
 		findOpts.SetLimit(opts.Limit())
 	} else {
-		findOpts.SetLimit(int64(r.searchLimit))
+		findOpts.SetLimit(int64(r.maxSearchLimit))
 	}
 
 	if opts.Skip() > 0 {

--- a/default.go
+++ b/default.go
@@ -4,5 +4,5 @@ const (
 	DefaultCreatedAtField = "createdAt"
 	DefaultUpdatedAtField = "updatedAt"
 	DefaultDeletedAtField = "deletedAt"
-	DefaultSearchLimit    = 10
+	DefaultSearchLimit    = 5000
 )

--- a/default.go
+++ b/default.go
@@ -4,5 +4,6 @@ const (
 	DefaultCreatedAtField = "createdAt"
 	DefaultUpdatedAtField = "updatedAt"
 	DefaultDeletedAtField = "deletedAt"
-	DefaultSearchLimit    = 5000
+	DefaultSearchLimit    = 10
+	MaxSearchLimit        = 5000
 )

--- a/repository.go
+++ b/repository.go
@@ -18,6 +18,7 @@ type Repository[M Model, D Dao, SF SearchFilters, SORD SearchOrderer, SO SearchO
 	log            Logger
 	logLevel       string
 	searchLimit    int
+	maxSearchLimit int
 	collectionName string
 	withTimestamps bool
 	updatedAtField string
@@ -46,6 +47,7 @@ func NewRepository[
 		log:            logger.New(),
 		logLevel:       strings.ToUpper(env.GetString(driver.MongoLogLevelEnv)),
 		searchLimit:    DefaultSearchLimit,
+		maxSearchLimit: MaxSearchLimit,
 		collectionName: collectionName,
 		withTimestamps: true,
 		updatedAtField: DefaultUpdatedAtField,


### PR DESCRIPTION
## Description

Agrega el max search limit al repositorio y lo fuerza en todos los casos.

## Task Context

### What is the current behavior?

El default search limit es de 10.
Si se le pasa un limit mayor a 10 no se esta validando. Podria pasarse un limit de 100000 y buscaria esa cantidad de documentos.

### What is the new behavior?

Se agrega una variable max search limit de 5000 y se fuerza que ese sea el limite maximo.

### Additional Context

<!-- Add here any additional context you think is important. -->

## Checklist

### Test Preview

